### PR TITLE
Add lists of available versions in summary endpoint

### DIFF
--- a/.github/workflows/bigquery.yml
+++ b/.github/workflows/bigquery.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run BigQuery
         run: |
           python -m pip install -U pip
-          python -m pip install google-cloud-bigquery
+          python -m pip install -r requirements.txt google-cloud-bigquery
           python scripts/bigquery.py
 
       # push changes back to the repo, this will trigger a new vercel build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 gql[requests]
+packaging

--- a/scripts/bigquery.py
+++ b/scripts/bigquery.py
@@ -26,7 +26,7 @@ query_job = client.query(QUERY.format(CLASSIFIER))
 withdrawn = {}
 deleted = {}
 active = {
-    k: sorted(set(v.split(",")), key=lambda x: Version(x))  # remove version dupes and sort
+    k: sorted(set(v.split(",")), key=Version, reverse=True)  # remove version dupes and sort in descending order
     for k, v in sorted(query_job.result(), key=lambda x: x[0].lower())
 }
 

--- a/scripts/bigquery.py
+++ b/scripts/bigquery.py
@@ -5,6 +5,7 @@ from typing import Tuple
 from urllib.error import HTTPError
 from urllib.request import urlopen
 
+from packaging.version import Version
 from google.cloud import bigquery
 
 PUBLIC = Path(__file__).parent.parent / "public"
@@ -25,7 +26,7 @@ query_job = client.query(QUERY.format(CLASSIFIER))
 withdrawn = {}
 deleted = {}
 active = {
-    k: sorted(set(v.split(",")))  # remove version dupes and sort
+    k: sorted(set(v.split(",")), key=lambda x: Version(x))  # remove version dupes and sort
     for k, v in sorted(query_job.result(), key=lambda x: x[0].lower())
 }
 

--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -16,6 +16,8 @@ import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
 
+from packaging.version import Version
+
 try:
     import conda
 except ImportError:
@@ -211,11 +213,11 @@ if __name__ == "__main__":
         # write summary map of pypi package name to conda channel/name
         (PUBLIC / "conda.json").write_text(json.dumps(CONDA_INDEX, indent=2))
 
-        # update the main index (summary) with the conda versions basic sorting
-        # should match the method used in scripts/bigquery.py for PyPI
-        # versions. If you need fancy sorting downstream use 'pacakging'.
+        # update the main index (summary) with the conda versions
+        # de-dupe and sort as in scripts/bigquery.py
         for pkg in PYPI_INDEX:
-            pkg["conda_versions"] = sorted(data.get(pkg["name"], {}).get("versions", []))
+            versions = data.get(pkg["name"], {}).get("versions", [])
+            pkg["conda_versions"] = sorted(set(versions), key=lambda v: Version(v))
 
     # write out data to public locations
     (PUBLIC / "summary.json").write_text(json.dumps(PYPI_INDEX, indent=2))

--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -217,7 +217,7 @@ if __name__ == "__main__":
         # de-dupe and sort as in scripts/bigquery.py
         for pkg in PYPI_INDEX:
             versions = data.get(pkg["name"], {}).get("versions", [])
-            pkg["conda_versions"] = sorted(set(versions), key=lambda v: Version(v))
+            pkg["conda_versions"] = sorted(set(versions), key=Version, reverse=True)
 
     # write out data to public locations
     (PUBLIC / "summary.json").write_text(json.dumps(PYPI_INDEX, indent=2))


### PR DESCRIPTION
The pending updates to the plugin dialog in napari (https://github.com/napari/napari/pull/5198) propose to show lists of available versions for plugins on both PyPI and conda (forge). The current implementation requires a number of requests to collect this data, and it's too slow when displaying the plugin dialog. After speaking with @goanpeca we thought this could be added to the https://npe2api.vercel.app/api/summary endpoint for efficient retrieval.

The result is something like this in `summary.json`:
```
[
...
  {
    "name": "napari-DeepSpot",
    "version": "0.0.7",
    "display_name": "napari-DeepSpot",
    "summary": "RNA spot enhancement for fluorescent microscopy images",
    "author": "Emmanuel Bouilhol",
    "license": "MIT",
    "home_page": "https://github.com/ebouilhol/napari-DeepSpot",
    "pypi_versions": [
      "0.0.0",
      "0.0.1",
      "0.0.2",
      "0.0.5",
      "0.0.6",
      "0.0.7"
    ],
    "conda_versions": [
      "0.0.7"
    ]
  },
...
]
```

A quick comparison locally suggests this adds something like 20s to the reindexing operation. I think it could be more efficient to get this info from the `npe2` CLI since this duplicates a request it is making to PyPI, but I'm not sure it makes sense to include it there.

I'm open to other ways of solving this issue so feedback is appreciated.