### PR TITLE
The conda api returns package builds in random order that leads to dummy commits

### DIFF
--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -117,6 +117,7 @@ def conda_data(package_name, channel="conda-forge", repodata=None) -> Tuple[str,
                     except Exception as exc:
                         print(f"{package_name} -> {type(exc)}: {exc}", file=sys.stderr)
                 data["builds"] = sorted(data["builds"])
+                data["conda_platforms"] = sorted(data["conda_platforms"])
                 return (package_name, data)
     return (package_name, {})
 

--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -116,6 +116,7 @@ def conda_data(package_name, channel="conda-forge", repodata=None) -> Tuple[str,
                         patch_api_data_with_repodata(data, repodata)
                     except Exception as exc:
                         print(f"{package_name} -> {type(exc)}: {exc}", file=sys.stderr)
+                data["builds"] = sorted(data["builds"])
                 return (package_name, data)
     return (package_name, {})
 


### PR DESCRIPTION
Dummy commits lead to additional vercel deployment, that uses global limit of deployments. 

![obraz](https://github.com/napari/npe2api/assets/3826210/65b7e792-8421-4678-8646-f191ae1f306e)
