### PR TITLE
Update `reindex.py` script to include manifest `visibility` and exclude packages with no PyPI versions

### DIFF
--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -159,6 +159,7 @@ if __name__ == "__main__":
                 "name": name,
                 "version": meta["version"],
                 "display_name": data["display_name"],
+                "visibility": data["visibility"],
                 "summary": meta["summary"],
                 "author": meta["author"],
                 "license": meta["license"],
@@ -187,10 +188,10 @@ if __name__ == "__main__":
         {
             **pkg,
             "pypi_versions": sorted(
-                active_pypi_versions.get(pkg["name"], []), key=Version, reverse=True
+                vs, key=Version, reverse=True
             ),
         }
-        for pkg in PYPI_INDEX
+        for pkg in PYPI_INDEX if len(vs := active_pypi_versions.get(pkg["name"], []) > 0)
     ]
 
     # now check conda for each package and write data to public/conda/{package}.json

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -29,6 +29,7 @@ def test_manifests_are_valid(mf_file):
     
     assert data["name"], "package has no name"
     assert data["package_metadata"]["version"], "package has no version"
+    assert data["visibility"], "package has no visibility"
     contributions = data["contributions"]
     
     if not any(contributions.values()):


### PR DESCRIPTION
Closes #31.

This PR updates the reindexing script to:

- include the manifest `visibility` in the extended summary
- exclude packages with no current PyPI versions from extended summary