### PR TITLE
Temporarily stop manifest cron job

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -1,12 +1,12 @@
 name: Fetch manifests
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
+  # pull_request:
+  #   branches:
+  #     - main
   workflow_dispatch:
   # schedule:
   #   # “Every 30 minutes”

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -8,9 +8,9 @@ on:
     branches:
       - main
   workflow_dispatch:
-  schedule:
-    # “Every 30 minutes”
-    - cron: "*/30 * * * *"
+  # schedule:
+  #   # “Every 30 minutes”
+  #   - cron: "*/30 * * * *"
 
 jobs:
   fetch:


### PR DESCRIPTION
PyPI now returns some custom HTML when trying to access the classifier search page from a non-browser. Since the `npe2 fetch` command sits inside a `while True` loop that only breaks on HTTP error, and no error is thrown, our fetch currently loops until PyPI spits the dummy, but no manifests are updated. 

This PR temporarily stops the cron job until we can figure out how to fix the fetch. The big query workflow will still run, updating our plugin index every 2 hours.