### PR TITLE
Add a notebook to view tables of json interactively

### DIFF
--- a/notebooks/QUICKSTART.md
+++ b/notebooks/QUICKSTART.md
@@ -1,0 +1,28 @@
+# Run notebooks
+
+## Create virtual environment
+
+Make sure that uv is installed (though it should work with only pip)
+
+```sh
+uv venv
+source .venv/bin/activate
+```
+
+## Install dependencies
+
+From the `notebooks` directory:
+
+```sh
+uv pip install -r requirements-nb.txt
+```
+
+## Start jupyterlab
+
+```sh
+jupyter lab
+```
+
+## Tables example
+
+Uses polars, great tables, and itables to display a json data file.

--- a/notebooks/requirements-nb.txt
+++ b/notebooks/requirements-nb.txt
@@ -1,0 +1,8 @@
+-r ../requirements.txt
+
+great_tables
+itables
+jupyter
+pandas
+polars
+

--- a/notebooks/summary.html
+++ b/notebooks/summary.html
@@ -1,0 +1,38 @@
+<table id="itables_e557a59b_2a20_4ffc_b322_2972af0891af" class="display nowrap" data-quarto-disable-processing="true" style="table-layout:auto;width:auto;margin:auto;caption-side:bottom">
+<thead>
+    <tr style="text-align: right;">
+      
+      <th>name</th>
+      <th>version</th>
+      <th>display_name</th>
+      <th>summary</th>
+      <th>author</th>
+      <th>license</th>
+      <th>home_page</th>
+    </tr>
+  </thead><tbody><tr>
+<td style="vertical-align:middle; text-align:left">
+
+Loading ITables v2.2.5 from the internet...
+(need <a href=https://mwouts.github.io/itables/troubleshooting.html>help</a>?)</td>
+</tr></tbody>
+</table>
+<link href="https://www.unpkg.com/dt_for_itables@2.0.13/dt_bundle.css" rel="stylesheet">
+<script type="module">
+    import {DataTable, jQuery as $} from 'https://www.unpkg.com/dt_for_itables@2.0.13/dt_bundle.js';
+
+    document.querySelectorAll("#itables_e557a59b_2a20_4ffc_b322_2972af0891af:not(.dataTable)").forEach(table => {
+        if (!(table instanceof HTMLTableElement))
+            return;
+
+        // Define the table data
+        const data = [["acquifer-napari", "0.0.2", "acquifer-napari", "Loader plugin for napari, to load Acquifer Imaging Machine datasets in napari, using dask for efficient lazy data-loading.", "Laurent Thomas", "GPL-3.0-only", null], ["ads_napari", "0.0.5", "ads_napari", "Axon/Myelin segmentation using AI", "NeuroPoly Lab", null, null], ["affinder", "0.4.0", "affinder", "Quickly find the affine matrix mapping one image to another using manual correspondence points annotation", "Juan Nunez-Iglesias", "BSD-3", "https://github.com/jni/affinder"]];
+
+        // Define the dt_args
+        let dt_args = {"layout": {"topStart": null, "topEnd": null, "bottomStart": null, "bottomEnd": null}, "order": [], "warn_on_selected_rows_not_rendered": true};
+        dt_args["data"] = data;
+
+        
+        new DataTable(table, dt_args);
+    });
+</script>

--- a/notebooks/tables_playground.ipynb
+++ b/notebooks/tables_playground.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df688416-8513-47e1-b836-5f95a9b87be4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# file path depends on what the current directory is and where you launched jupyter lab\n",
+    "# This filename assumes you started jupyterlab from the notebook directory\n",
+    "DATA_FILE = \"../public/summary.json\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b903d94-27f6-4d0a-93f0-e07e2501de4e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's use polars over pandas for performance\n",
+    "import polars as pl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82c76b46-aaec-46e1-a3ca-b491cd3a9988",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import great_tables for nicely styled tables\n",
+    "from great_tables import GT, md, html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34881b4e-0ca9-4577-b14a-8b8ad4305d38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import and initialize itables for interactive tables\n",
+    "from itables import init_notebook_mode, show\n",
+    "init_notebook_mode(all_interactive=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c01c8178-bc2d-4e7d-a9fb-217122121df9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Prevent itables from downsampling data\n",
+    "import itables.options as opt\n",
+    "opt.maxBytes = \"512KB\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b26c0b4c-8452-4f5b-9d51-855a43e422c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_summary = pl.read_json(DATA_FILE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27b9f28a-9627-4155-a5f3-ecc9fc130ba3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Polars default output\")\n",
+    "df_summary.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35f7229a-49d0-481d-abf5-9b5866933395",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Great Tables default output\")\n",
+    "GT(df_summary.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99b4939d-a0de-4932-bd72-09657d6caf9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Interactive table default\")\n",
+    "show(df_summary)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0060ed2c-34b2-4a11-b125-61cb517f50cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Output as an html page (Quarto is also an option)\n",
+    "from IPython.display import HTML, display\n",
+    "\n",
+    "from itables import to_html_datatable\n",
+    "\n",
+    "html = to_html_datatable(df_summary.head(3), display_logo_when_loading=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37cebbda-6896-46f3-bd0a-43e90232439c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(html)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c5c10c9-58a9-4163-98a7-3376bd73cbae",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds a notebooks directory which includes:
- additional requirements to run the notebook
- adds a quickstart markdown file
- read a json file, display polars dataframe in Great Tables, and in interactive iTables
- adds an example of exporting the itable to html (it also can be used with quarto)

@DragaDoncila This may be useful as you work through the plugin stuff for 0.6.

Also proof of concept for https://github.com/napari/hub-lite/issues/6