### PR TITLE
Add `project_url` to `extended_summary` in addition to `home_page`

### DIFF
--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -163,6 +163,7 @@ if __name__ == "__main__":
                 "author": meta["author"],
                 "license": meta["license"],
                 "home_page": meta["home_page"],
+                "project_url": meta["project_url"],
             }
         )
 


### PR DESCRIPTION
This PR is required to address [napari-plugin-template/#60](https://github.com/napari/napari-plugin-template/issues/60).

Currently, `extended_summary.json` only saves the `home_page` field from the full `project_metadata` written to each manifest file. However, the `home_page` field is [deprecated](https://packaging.python.org/en/latest/specifications/core-metadata/#home-page) and the PyPA recommends using well-known url labels in the `pyproject.toml` `project.urls` section.

This PR adds this field to `extended_summary.json` so that in `napari-plugin-manager` and other places, e.g. hub lite, we can appropriately parse the website URLs provided by the plugins.

Eventually we may wish to fully deprecate reading of the `home_page` field, but it is too early for that now, as many plugins still use it - in fact every plugin with a clickable title in the plugin manager must use it...

