### PR TITLE
Add pypi endpoint to fetch individual plugin pypi info

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The rest API used by napari to query plugins
         - the full manifest for a given plugin
     - <https://npe2api.vercel.app/api/conda>
         - map of {pypi_name -> conda_channel/package_name}
+    - [https://npe2api.vercel.app/api/pypi/{plugin-name}](https://npe2api.vercel.app/api/pypi/napari-animation)
+        - PyPI info for a plugin.
     - [https://npe2api.vercel.app/api/conda/{plugin-name}](https://npe2api.vercel.app/api/conda/napari-animation)
         - conda info for a plugin. *name is pypi_name, not conda-name*
     - <https://npe2api.vercel.app/errors.json>

--- a/pages/api/pypi/[slug].js
+++ b/pages/api/pypi/[slug].js
@@ -1,0 +1,12 @@
+import path from "path";
+import { promises as fs } from "fs";
+
+export default async function handler(req, res) {
+  const { slug } = req.query;
+  const jsonDirectory = path.join(process.cwd(), "public", "pypi");
+  const fileContents = await fs.readFile(
+    jsonDirectory + `/${slug}.json`,
+    "utf8"
+  );
+  res.status(200).send(JSON.stringify(JSON.parse(fileContents)));
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,6 +10,7 @@ export default function home({ data }) {
       <h3>(This top page is for humans)</h3>
       <p>Plugin index: <Link href={`/api/plugins`}><a>/api/plugins</a></Link></p>
       <p>Summary info: <Link href={`/api/extended_summary`}><a>/api/extended_summary</a></Link></p>
+      <p>PyPI information: see PyPI info for each plugin at /api/conda/pypi_name</p>
       <p>Conda index: <Link href={`/api/conda`}><a>/api/conda</a></Link>  (see conda info for each plugin at /api/conda/pypi_name)</p>
       <p>Fetch errors: <Link href={`/errors.json`}><a>errors.json</a></Link></p>
       <h3>manifests</h3>


### PR DESCRIPTION
In looking to fix the issue with release dates in napari/hub-lite#18, I realized we'd need to grab the `pypi` file for each plugin, as it contains the dates for each release. 

The `conda` file has dates for each release too, but not all plugins have conda, so I think it makes sense to fetch this info from pypi at first.

This PR adds a `pypi/<plugin-name>` endpoint, so that we can access the pypi release information.