### PR TITLE
Add Code of Conduct section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ If you are interested in contributing to this repo, see the [CONTRIBUTING.md](./
 
 ## Code of conduct
 
-`npe2api` is maintained by the [napari](https://napari.org/stable/) community. The `napari` community has a [Code of Conduct](https://napari.org/stable/community/code_of_conduct.html) that should be honored by everyone who participates in the `napari` community.
+`npe2api` is maintained by the [napari](https://napari.org/) community. The `napari` community has a [Code of Conduct](https://napari.org/dev/community/code_of_conduct.html) that should be honored by everyone who participates in the `napari` community.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ The endpoint for the API is: <https://api.napari.org>
 ## Contributing
 
 If you are interested in contributing to this repo, see the [CONTRIBUTING.md](./CONTRIBUTING.md) page.
+
+## Code of conduct
+
+`npe2api` is maintained by the [napari](https://napari.org/stable/) community. The `napari` community has a [Code of Conduct](https://napari.org/stable/community/code_of_conduct.html) that should be honored by everyone who participates in the `napari` community.


### PR DESCRIPTION
Adds code of conduct section (taken from `napari/napari`) to this repo. As well as being good practice (and something we should probably do for all org repos), this is in preparation for asking netlify for an [Open Source Plan](https://www.netlify.com/legal/open-source-policy/) so that we can move away from Vercel.