### PR TITLE
Fix github fetching of data

### DIFF
--- a/lib/pyapi/github.py
+++ b/lib/pyapi/github.py
@@ -105,7 +105,7 @@ def _activity(owner: str, name: str) -> GithubActivity:
     gql_client = Client(transport=transport, fetch_schema_from_transport=False)
 
     variables = {"owner": owner, "name": name}
-    data = gql_client.execute(query_activity, variables)["repository"]
+    data = gql_client.execute(query_activity, variable_values=variables)["repository"]
     last_commit_node = data["defaultBranchRef"]["target"]["history"]["nodes"][0]
     user = last_commit_node["author"].get("user") or {}
     date = last_commit_node["committedDate"]
@@ -168,7 +168,7 @@ def org_repo(name: PluginName) -> tuple[str, str] | None:
         [info.get("home_page"), info.get("package_url"), info.get("project_url")],
         (info.get("project_urls") or {}).values(),
     ):
-        if match := GITHUB_RE.match(link):
+        if link is not None and (match := GITHUB_RE.match(link)):
             org, repo = match.groups()
             if repo.endswith(".git"):
                 repo = repo[:-4]

--- a/lib/pyapi/github.py
+++ b/lib/pyapi/github.py
@@ -138,18 +138,16 @@ def codecov(name: PluginName) -> CoverageInfo | None:
     if CODECOV_API_TOKEN := os.environ.get("CODECOV_API_TOKEN"):
         headers["Authorization"] = CODECOV_API_TOKEN
 
-    url = "https://codecov.io/api/gh/{}/{}".format(*result)
+    url = "https://api.codecov.io/api/v2/gh/{}/repos/{}/commits/".format(*result)
     data = requests.get(url, headers=headers).json()
-    commit: dict = data.get("commit")
-    if not commit:
-        commit = next((c for c in data.get("commits", []) if c.get("merged")), {})
+    commit: dict = next(iter(data.get("results", [])), {})
     if not commit or not (totals := commit.get("totals")):
         return None
 
     return CoverageInfo(
-        hits=totals["h"],
-        lines=totals["n"],
-        ratio=float(totals["c"]),
+        hits=totals["hits"],
+        lines=totals["lines"],
+        ratio=float(totals["coverage"]),
         commit=commit["commitid"],
         date=commit["timestamp"],
         branch=commit["branch"],

--- a/lib/pyapi/github.py
+++ b/lib/pyapi/github.py
@@ -223,7 +223,9 @@ def repo_summary(name: PluginName) -> RepoSummary:
         raise ValueError(f"No github repo found for {name!r}")
     url = "https://github.com/{}/{}".format(*result)
     act = activity(name)
-    return RepoSummary(url=url, activity=act, coverage=codecov(name, act["default_branch"]))
+    return RepoSummary(
+        url=url, activity=act, coverage=codecov(name, act["default_branch"])
+    )
 
 
 def _try_fetch_and_store_github_info(name: PluginName):

--- a/lib/pyapi/github.py
+++ b/lib/pyapi/github.py
@@ -129,7 +129,7 @@ def _activity(owner: str, name: str) -> GithubActivity:
     )
 
 
-def codecov(name: PluginName) -> CoverageInfo | None:
+def codecov(name: PluginName, default_branch: str | None = None) -> CoverageInfo | None:
     """Return coverage using codecov api."""
     if not (result := org_repo(name)):
         return None
@@ -139,6 +139,11 @@ def codecov(name: PluginName) -> CoverageInfo | None:
         headers["Authorization"] = CODECOV_API_TOKEN
 
     url = "https://api.codecov.io/api/v2/gh/{}/repos/{}/commits/".format(*result)
+    # only get commit coverage info for the default branch
+    # if we couldn't find a default branch, we don't assume
+    if not default_branch:
+        return None
+    url += f"?branch={default_branch}"
     data = requests.get(url, headers=headers).json()
     commit: dict = next(iter(data.get("results", [])), {})
     if not commit or not (totals := commit.get("totals")):
@@ -217,7 +222,8 @@ def repo_summary(name: PluginName) -> RepoSummary:
     if not (result := org_repo(name)):
         raise ValueError(f"No github repo found for {name!r}")
     url = "https://github.com/{}/{}".format(*result)
-    return RepoSummary(url=url, activity=activity(name), coverage=codecov(name))
+    act = activity(name)
+    return RepoSummary(url=url, activity=act, coverage=codecov(name, act["default_branch"]))
 
 
 def _try_fetch_and_store_github_info(name: PluginName):


### PR DESCRIPTION
A couple of fixes for fetching github data:

- update usage of `gql_client.execute` to pass keyword arguments only since their API change
- avoid a pypi_info issue where the given link was sometimes `None` and `re.match` errored as a result
- update codecov API usage to v2 since v1 is now deprecated. Passing `default_branch` from the GitHub activity, we grab the latest commit to that branch (if available) and get its detail