### PR TITLE
Log and continue on error during package fetch

### DIFF
--- a/scripts/find_by_classifier.py
+++ b/scripts/find_by_classifier.py
@@ -63,14 +63,15 @@ def _find_by_classifier(classifier: str) -> dict[str, list[str]]:
     }
 
 
-def _fetch_packge_info(name: str) -> tuple[str, str]:
+def _fetch_packge_info(name: str) -> tuple[str, dict | None]:
     normalized_name = canonicalize_name(name)
     try:
         with urlopen(f"https://pypi.org/pypi/{name}/json") as f:
             info = json.load(f)
         (PYPI_DIR / f"{normalized_name}.json").write_text(json.dumps(info, indent=2))
-    except HTTPError:
-        return None
+    except HTTPError as e:
+        print(f"  ⚠️ HTTP {e.code} fetching {name}", file=sys.stderr)
+        return name, None
     return name, info
 
 
@@ -94,9 +95,15 @@ if __name__ == "__main__":
             "active": "✅",
             "withdrawn": "🔵",
             "deleted": "❌",
+            "error": "⚠️",
         }
         for name, info in pool.map(_fetch_packge_info, all_packages_with_classifier):
             normalized_name = canonicalize_name(name)
+
+            if info is None:
+                print(f"{icon['error']} {normalized_name} (could not fetch info)")
+                continue
+
             status = "active"
             versions = _prune_yanked_versions(info, all_packages_with_classifier[name])
 


### PR DESCRIPTION
# Description

Currently, the update action runs are constantly failing: https://github.com/napari/npe2api/actions/workflows/update.yml

This adds a print for the HTTP error and allows the script to continue instead of crashing.

Something like:
```
  ⚠ HTTP 404 fetching some-package
⚠ some-package (could not fetch info)
```