### PR TITLE
Explicitly set commit author to napari-bot

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -89,3 +89,5 @@ jobs:
           publish_dir: ./gh-pages
           publish_branch: gh-pages
           force_orphan: true
+          user_name: 'napari-bot'
+          user_email: 'napari-bot@users.noreply.github.com'


### PR DESCRIPTION
To help @psobolewskiPhD activity status set commits author to `gh-pages` to napari-bot.  